### PR TITLE
Get question by disciplines

### DIFF
--- a/app/v1/exams/[year]/questions/discipline/[discipline]/route.ts
+++ b/app/v1/exams/[year]/questions/discipline/[discipline]/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest } from 'next/server'
+import { RateLimiter } from '@/lib/api/rate-limit';
+import { logger } from '@/lib/api/logger';
+import { getExamDetails } from '@/lib/api/exams/get-exam-details';
+import { EnemApiError, handleAndReturnErrorResponse } from '@/lib/api/errors';
+import {
+    GetQuestionsQuerySchema,
+} from '@/lib/zod/schemas/questions';
+import { getSearchParamsAsObject } from '@/lib/utils';
+import { getQuestionByDisciplines } from '@/lib/api/questions/get-question-by-disciplines';
+
+const rateLimiter = new RateLimiter();
+
+type Params = {
+    year: string;
+    discipline: string;
+};
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Params }, 
+){
+    try {
+        const { rateLimitHeaders } = rateLimiter.check(request);
+        
+        await logger(request);
+        
+        const searchParams = request.nextUrl.searchParams;
+        
+        let { limit, offset } = GetQuestionsQuerySchema.parse(
+            getSearchParamsAsObject(searchParams),
+        );
+
+        const exam = await getExamDetails(params.year);
+
+        if (!exam) {
+            throw new EnemApiError({
+                code: 'not_found',
+                message: `No exam found for year ${params.year}`,
+            });
+        }
+
+        const questionByDisciplines = await getQuestionByDisciplines({
+            year: params.year,
+            discipline: params.discipline
+        });
+
+        if (!questionByDisciplines) {
+            throw new EnemApiError({
+                code: 'not_found',
+                message: `No questions found for discipline ${params.discipline}`,
+            });
+        }
+
+        return Response.json({
+            metadata: {
+                limit: Number(limit),
+                offset: Number(offset),
+                total: exam.questions.length,
+                hasMore:
+                    Number(offset) + Number(limit) < exam.questions.length,
+            },
+            questionByDisciplines,
+        },{ headers: rateLimitHeaders })
+    } catch (error) {
+        return handleAndReturnErrorResponse(error);
+        
+    }
+}

--- a/lib/api/questions/get-question-by-disciplines.ts
+++ b/lib/api/questions/get-question-by-disciplines.ts
@@ -1,0 +1,70 @@
+import z from '@/lib/zod';
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import { QuestionDetailSchema } from '@/lib/zod/schemas/questions';
+
+
+type GetQuestionDetailsPayload = {
+    year: string | number;
+    discipline: string;
+};
+
+type Discipline = {
+    label: string;
+    value: string;
+};
+
+type Language = {
+    label: string;
+    value: string;
+};
+
+type Question = {
+    title: string;
+    index: number;
+    discipline: string;
+    language: string | null;
+};
+
+type QuestionDetailS = {
+    title: string;
+    year: number;
+    disciplines: Discipline[];
+    languages: Language[];
+    questions: Question[];
+};
+
+export async function getQuestionByDisciplines(payload: GetQuestionDetailsPayload) {
+    let filePath = `${process.cwd()}/public/${payload.year}/details.json`;
+
+    if (!existsSync(filePath)) {
+        return null;
+    }
+
+    const yearRaw = await readFile(filePath, 'utf-8');
+    
+    const year = JSON.parse(yearRaw) as QuestionDetailS;
+    
+    let questionsFilteredByDiscipline: Array< z.infer<typeof QuestionDetailSchema>> = [];
+    
+    for (let i = 0; i < year.questions.length; i++) {
+        
+        const question: Question  = year.questions[i];
+        
+        if (question.discipline === payload.discipline) {
+
+            let filePathQuestion = `${process.cwd()}/public/${payload.year}/questions/${question.index}/details.json`;
+            
+            if (question.language) {   
+                filePathQuestion = `${process.cwd()}/public/${payload.year}/questions/${question.index}-${question.language}/details.json`;        
+            }            
+
+            const questionRaw = await readFile(filePathQuestion, 'utf-8');
+            
+            const questionSelected = JSON.parse(questionRaw) as typeof QuestionDetailSchema;
+            const questionSelectedParsed = QuestionDetailSchema.parse(questionSelected);
+            questionsFilteredByDiscipline.push(questionSelectedParsed);
+        }
+    }
+    return questionsFilteredByDiscipline.length > 0 ? questionsFilteredByDiscipline : null;
+}

--- a/lib/openapi/questions/get-question-by-disciplines.ts
+++ b/lib/openapi/questions/get-question-by-disciplines.ts
@@ -1,0 +1,36 @@
+import z from '@/lib/zod';
+import { ZodOpenApiOperationObject } from 'zod-openapi';
+import { ExamYearPath } from '@/lib/zod/schemas/exams';
+import {
+    GetQuestionsResponseSchema,
+    GetQuestionByDisciplinesQuerySchema,
+    QuestionDisciplinePath,
+} from '@/lib/zod/schemas/questions';
+
+import { openApiErrorResponses } from '@/lib/openapi/responses';
+
+export const getQuestionByDisciplines: ZodOpenApiOperationObject = {
+    operationId: 'getQuestionByDisciplines',
+    summary: 'Listar questões por disciplinas',
+    description: 'Listar questões de uma prova por disciplinas',
+    requestParams: {
+        path: z.object({
+            year: ExamYearPath,
+            discipline: QuestionDisciplinePath
+        }),
+        query: GetQuestionByDisciplinesQuerySchema,
+    },
+    responses: {
+        '200': {
+            description: 'Lista de questões de uma disciplina',
+            content: {
+                'application/json': {
+                    schema: GetQuestionsResponseSchema,
+                },
+            },
+        },
+        ...openApiErrorResponses
+    },
+    tags: ['Questões'],
+
+};

--- a/lib/openapi/questions/index.ts
+++ b/lib/openapi/questions/index.ts
@@ -1,6 +1,7 @@
 import { ZodOpenApiPathsObject } from 'zod-openapi';
 import { getQuestions } from './get-questions';
 import { getQuestionDetails } from './get-question-details';
+import { getQuestionByDisciplines } from './get-question-by-disciplines';
 
 export const questionsPaths: ZodOpenApiPathsObject = {
     '/exams/{year}/questions': {
@@ -8,5 +9,8 @@ export const questionsPaths: ZodOpenApiPathsObject = {
     },
     '/exams/{year}/questions/{index}': {
         get: getQuestionDetails,
+    },
+    '/exams/{year}/questions/discipline/{discipline}': {
+        get: getQuestionByDisciplines,
     },
 };

--- a/lib/zod/schemas/questions.ts
+++ b/lib/zod/schemas/questions.ts
@@ -157,3 +157,17 @@ export const GetQuestionDetailsQuerySchema = z.object({
         .describe('O idioma desejado da questão')
         .openapi({ example: 'ingles' }),
 });
+
+export const QuestionDisciplinePath = z.string().openapi({
+    ref: 'discipline',
+    example: 'linguagens',
+    description: 'A disciplina da questão',
+});
+
+export const GetQuestionByDisciplinesQuerySchema = z.object({
+    disciplines: z
+        .array(z.string())
+        .describe('As disciplinas desejadas das questões')
+        .openapi({ example: ['ciencias-natureza','ciencias-humanas','matematica', 'linguagens'] }),
+});
+


### PR DESCRIPTION
**Resumo do Pull Request:**

Este pull request adiciona uma nova funcionalidade à API para permitir a recuperação de questões do ENEM com base em disciplinas e ano. As principais alterações incluem:

- **Criação do endpoint `getQuestionByDisciplines`**: Adiciona um novo endpoint para buscar questões filtradas por disciplinas específicas e ano.
- **Implementação da função `getQuestionByDisciplines`**: Função responsável por recuperar as questões do banco de dados com base nos parâmetros fornecidos (disciplina e ano).
- **Adição da rota**: Implementa a rota correspondente no servidor para a nova funcionalidade.
- **Definição do schema `GetQuestionByDisciplinesQuerySchema`**: Adiciona o schema para validar os parâmetros de consulta usados na nova API.

Essas alterações permitem aos usuários obter questões específicas de acordo com a disciplina e o ano desejados, melhorando a flexibilidade e a usabilidade da aplicação.
