### PR TITLE
Ajuste no gabarito de linguagens das questões 15, 25 e 38 do ENEM 2021

### DIFF
--- a/public/2021/questions/15/details.json
+++ b/public/2021/questions/15/details.json
@@ -6,7 +6,7 @@
     "discipline": "linguagens",
     "context": "**TEXTO I**\n\nCorreu à sala dos retratos, abriu o piano, sentou-se e espalmou as mãos no teclado. Começou a tocar alguma coisa própria, uma inspiração real e pronta, uma polca, uma polca buliçosa, como dizem os anúncios. Nenhuma repulsa da parte do compositor; os dedos iam arrancando as notas, ligando-as, meneando-as; dir-se-ia que a musa compunha e bailava a um tempo. \\[…….\\] Compunha só, teclando ou escrevendo, sem os vãos esforços da véspera, sem exasperação, sem nada pedir ao céu, sem interrogar os olhos de Mozart. Nenhum tédio. Vida, graça, novidade, escorriam-lhe da alma como de uma fonte perene.\n\nASSIS, M. Um homem célebre. Disponivel em: www.biblio.com.br.  \nAcesso em: 2 jun. 2019.\n\n**TEXTO II**\n\nUm homem célebre expõe o suplicio do músico popular que busca atingir a sublimidade da obra-prima clássica, e com ela a galeria dos imortais, mas que é traído por uma disposição interior incontrolável que o empurra implacavelmente na direção oposta. Pestana, célebre nos saraus, salões, bailes e ruas do Rio de Janeiro por suas composições irresistivelmente dançantes, esconde-se dos rumores à sua volta num quarto povoado de ícones da grande música europeia, mergulha nas sonatas do classicismo vienense, prepara-se para o supremo salto criativo e, quando dá por si, é o autor de mais uma inelutável e saltitante polca.\n\nWISNIK, J. M. Machado maxixe: o caso Pestana. Teresa: revista de literatura brasileira,  \n2004 (adaptado).",
     "files": [],
-    "correctAlternative": "E",
+    "correctAlternative": "D",
     "alternativesIntroduction": "O conto de Machado de Assis faz uma referência velada a maxixe, gênero musical inicialmente associado à escravidão e à mestiçagem. No Texto II, o conflito do personagem em compor obras do gênero é representativo da",
     "alternatives": [
         {
@@ -31,13 +31,13 @@
             "letter": "D",
             "text": "Tensa relação entre o erudito e o popular na constituição da música brasileira.",
             "file": null,
-            "isCorrect": false
+            "isCorrect": true
         },
         {
             "letter": "E",
             "text": "Importância atribuída à música clássica a sociedade brasileira do século XIX.",
             "file": null,
-            "isCorrect": true
+            "isCorrect": false
         }
     ]
 }

--- a/public/2021/questions/25/details.json
+++ b/public/2021/questions/25/details.json
@@ -6,7 +6,7 @@
     "discipline": "linguagens",
     "context": "– O senhor pensa que só porque o deixaram morar neste país pode logo ir fazendo o que quer? Nunca ouviu falar num troço chamado autoridades constituídas? Não sabe que tem de conhecer as leis do país? Não sabe que existe uma coisa chamada Exército Brasileiro, que o senhor tem de respeitar? Que negócio é esse? {…\\] Eu ensino o senhor a cumprir a lei, ali no duro: “dura lex”! Seus filhos são uns moleques e outra vez que eu souber que andaram incomodando o General, vai tudo em cana. Morou? Sei como tratar gringos feito o senhor. \\[…\\] Foi então que a mulher do vizinho do General interveio:  \n– Era tudo que o senhor tinha a dizer a meu marido? Odelegado apenas olhou-a, espantado com o atrevimento.  \n– Pois então fique sabendo que eu também sei tratar tipos como o senhor. Meu marido não é gringo nem meus filhos são moleques. Se por acaso importunaram o General, ele que viesse falar comigo, pois o senhor que sou brasileira, sou prima de um Major do Exército, sobrinha de um Coronel, e filha de um General! Morou? Estarrecido, o delegado só teve força para engolir em seco e balbuciar humildemente: – Da ativa, minha senhora?.\n\nSABINO, F. A mulher do vizinho. In: **Os melhores contos**. Rio de Janeiro: Record, 1986.",
     "files": [],
-    "correctAlternative": "E",
+    "correctAlternative": "B",
     "alternativesIntroduction": "A representação do discurso intimidador engendrada no fragmento é responsável por",
     "alternatives": [
         {
@@ -19,7 +19,7 @@
             "letter": "B",
             "text": "Conferir à narrativa um tom anedótico.",
             "file": null,
-            "isCorrect": false
+            "isCorrect": true
         },
         {
             "letter": "C",
@@ -37,7 +37,7 @@
             "letter": "E",
             "text": "Exaltar relações de poder estereotipadas.",
             "file": null,
-            "isCorrect": true
+            "isCorrect": false
         }
     ]
 }

--- a/public/2021/questions/38/details.json
+++ b/public/2021/questions/38/details.json
@@ -6,14 +6,14 @@
     "discipline": "ciencias-humanas",
     "context": "Se for possível, manda-me dizer:  \n– É lua cheia. A casa está vazia –  \nManda-me dizer, e o paraíso  \nHá de ficar mais perto, e mais recente  \nMe há de parecer teu rosto incerto.  \nManda-me buscar se tens o dia  \nTão longo como a noite. Se é verdade  \nQue sem mim só vês monotonia.  \nE se te lembras do brilho das marés  \nDe alguns peixes rosados  \nNumas águas  \nE dos meus pés molhados, manda-me dizer:  \n– É lua nova –  \nE revestida de luz te volto a ver.\n\nHILST, H. **Júbilio, memória, noviciado da paixão**. São Paulo: Cia das Letras, 2018.",
     "files": [],
-    "correctAlternative": "A",
+    "correctAlternative": "C",
     "alternativesIntroduction": "Falando ao outro, o eu lírico revela-se vocalizando um desejo que remete ao",
     "alternatives": [
         {
             "letter": "A",
             "text": "Ceticismo quanto à possibilidade do reencontro.",
             "file": null,
-            "isCorrect": true
+            "isCorrect": false
         },
         {
             "letter": "B",
@@ -25,7 +25,7 @@
             "letter": "C",
             "text": "Sonho de autorrealização desenhado pela memória.",
             "file": null,
-            "isCorrect": false
+            "isCorrect": true
         },
         {
             "letter": "D",


### PR DESCRIPTION
Essa mudança altera o campo `correctAlternative` das questões 15, 25 e 38 do ENEM 2021, além de setar o campo `isCorrect` para as alternativas corretas.

<img width="533" height="753" alt="image" src="https://github.com/user-attachments/assets/20194161-9406-4a18-978c-9a43d1a3841f" />

[Gabarito oficial do ENEM 2021](https://download.inep.gov.br/enem/provas_e_gabaritos/2021_GB_impresso_D1_CD1.pdf)

Explicações de cada questão:
[Questão 15](https://plataformaassaad.com.br/questao-15-caderno-azul-do-enem-2021-dia-1/)
[Questão 25](https://plataformaassaad.com.br/questao-25-caderno-azul-do-enem-2021-dia-1/)
[Questão 38](https://plataformaassaad.com.br/questao-38-caderno-azul-do-enem-2021-dia-1/)